### PR TITLE
Speedup combine submission

### DIFF
--- a/ahtt/scripts/submit_point.py
+++ b/ahtt/scripts/submit_point.py
@@ -10,7 +10,7 @@ import glob
 import copy
 from collections import OrderedDict
 
-from utilities import syscall, submit_job, aggregate_submit, chunks, get_nbin, input_base, input_bkg, input_sig, index_list
+from utilities import syscall, submit_job, aggregate_submit, flush_jobs, chunks, get_nbin, input_base, input_bkg, input_sig, index_list
 from desalinator import prepend_if_not_empty, tokenize_to_list, remove_spaces_quotes
 from argumentative import common_point, common_common, common_fit_pure, common_fit_forwarded, make_datacard_pure, make_datacard_forwarded, common_1D, common_submit
 from hilfemir import combine_help_messages, submit_help_messages
@@ -155,7 +155,7 @@ if __name__ == '__main__':
                 )
 
                 submit_job(agg, jname, jarg, args.jobtime, 1, "",
-                           "." if rundc else "$(readlink -f " + pnt + args.tag + ")", scriptdir + "/single_point_ahtt.py", True, args.runlocal)
+                           "." if rundc else pnt + args.tag, scriptdir + "/single_point_ahtt.py", True, args.runlocal)
         elif runpull:
             if args.nnuisance < 0:
                 args.nnuisance = 25
@@ -210,7 +210,7 @@ if __name__ == '__main__':
                 jarg += " --impact-nuisances '{grp};{nui}'".format(grp = group, nui = ",".join(nuisance))
 
                 submit_job(agg, jname, jarg, args.jobtime, 1, "",
-                           "." if rundc else "$(readlink -f " + pnt + args.tag + ")", scriptdir + "/single_point_ahtt.py", True, args.runlocal)
+                           "." if rundc else pnt + args.tag, scriptdir + "/single_point_ahtt.py", True, args.runlocal)
         else:
             logs = glob.glob(pnt + args.tag + "/" + job_name + ".o*")
 
@@ -219,8 +219,6 @@ if __name__ == '__main__':
                     continue
 
             submit_job(agg, job_name, job_arg, args.jobtime, 1, "",
-                       "." if rundc else "$(readlink -f " + pnt + args.tag + ")", scriptdir + "/single_point_ahtt.py", True, args.runlocal)
+                       "." if rundc else pnt + args.tag, scriptdir + "/single_point_ahtt.py", True, args.runlocal)
 
-    if os.path.isfile(agg):
-        syscall('condor_submit {agg}'.format(agg = agg), False)
-        syscall('rm {agg}'.format(agg = agg), False)
+    flush_jobs(agg)

--- a/ahtt/scripts/submit_twin.py
+++ b/ahtt/scripts/submit_twin.py
@@ -14,7 +14,7 @@ import json
 import math
 from datetime import datetime
 
-from utilities import syscall, submit_job, aggregate_submit, input_base, input_bkg, input_sig, min_g, max_g, tuplize, recursive_glob, index_list
+from utilities import syscall, submit_job, aggregate_submit, flush_jobs, input_base, input_bkg, input_sig, min_g, max_g, tuplize, recursive_glob, index_list
 from desalinator import prepend_if_not_empty, tokenize_to_list, remove_spaces_quotes
 from argumentative import common_common, common_fit_pure, common_fit_forwarded, make_datacard_pure, make_datacard_forwarded, common_2D, common_submit
 from hilfemir import combine_help_messages, submit_help_messages
@@ -281,7 +281,7 @@ if __name__ == '__main__':
                     )
 
                     submit_job(agg, jname, jarg, args.jobtime, 1, "",
-                               "." if rundc else "$(readlink -f " + pstr + args.tag + ")", scriptdir + "/twin_point_ahtt.py", True, args.runlocal)
+                               "." if rundc else pstr + args.tag, scriptdir + "/twin_point_ahtt.py", True, args.runlocal)
 
             if runfc:
                 if args.fcmode != "" and ggrid == "":
@@ -337,7 +337,7 @@ if __name__ == '__main__':
                                 jarg += " --save-toy"
 
                         submit_job(agg, jname, jarg, args.jobtime, 1, "",
-                                   "." if rundc else "$(readlink -f " + pstr + args.tag + ")", scriptdir + "/twin_point_ahtt.py", True, args.runlocal)
+                                   "." if rundc else pstr + args.tag, scriptdir + "/twin_point_ahtt.py", True, args.runlocal)
         else:
             logs = glob.glob(pstr + args.tag + "/" + job_name + ".o*")
 
@@ -355,9 +355,7 @@ if __name__ == '__main__':
             #job_mem = "12 GB" if runprepost and not (args.frzbb0 or args.frzbbp or args.frznui) else ""
             job_mem = ""
             submit_job(agg, job_name, job_arg, args.jobtime, 1, job_mem,
-                       "." if rundc else "$(readlink -f " + pstr + args.tag + ")", scriptdir + "/twin_point_ahtt.py",
+                       "." if rundc else pstr + args.tag, scriptdir + "/twin_point_ahtt.py",
                        True, runcompile or args.runlocal)
 
-        if os.path.isfile(agg):
-            syscall('condor_submit {agg}'.format(agg = agg), False)
-            syscall('rm {agg}'.format(agg = agg), False)
+        flush_jobs(agg)

--- a/ahtt/scripts/utilities.py
+++ b/ahtt/scripts/utilities.py
@@ -48,7 +48,7 @@ kfactor_file_name = {
 def make_submission_script_header():
 
     script = "Job_Proc_ID = $(Process) + 1 \n"
-    script += "executable = {htcdir}condorRun.sh\n".format(htcdir=condordir)
+    script += "executable = {htcdir}{script}\n".format(htcdir=condordir, script=condorrun)
     script += "notification = error\n"
     script += 'requirements = (OpSysAndVer == "CentOS7")\n'
 

--- a/ahtt/scripts/utilities.py
+++ b/ahtt/scripts/utilities.py
@@ -379,8 +379,8 @@ def flush_jobs(job_agg):
         with open(job_agg, "w") as f:
             f.write(script)
 
-        #syscall("condor_submit {job_agg}".format(job_agg=job_agg), True)
-        #os.remove(job_agg)
+        syscall("condor_submit {job_agg}".format(job_agg=job_agg), True)
+        os.remove(job_agg)
 
         current_submissions = []
     else:

--- a/ahtt/scripts/utilities.py
+++ b/ahtt/scripts/utilities.py
@@ -48,7 +48,7 @@ kfactor_file_name = {
 def make_submission_script_header():
 
     script = "Job_Proc_ID = $(Process) + 1 \n"
-    script += "executable = {htcdir}{script}\n".format(htcdir=condordir, script=condorrun)
+    script += "executable = {script}\n".format(script=condorrun)
     script += "notification = error\n"
     script += 'requirements = (OpSysAndVer == "CentOS7")\n'
 


### PR DESCRIPTION
Speeds up the combine submission drastically. Uses the same method as for the smoothing, i.e. creating the submission scripts in pure python, keeping them in memory for different jobs, and then flushing & submitting them in one go. Currently I set the max number of jobs submitted at once at 4000.

Tested to work both on NAF and lxplus.